### PR TITLE
Don't implode rules with pipe connector.

### DIFF
--- a/src/FieldTypesRequest.php
+++ b/src/FieldTypesRequest.php
@@ -86,7 +86,6 @@ abstract class FieldTypesRequest extends FormRequest
     {
         return $this->fields->getRules()
             ->union($this->getRules())
-            ->map->implode('|')
             ->setKeyOrder($this->fieldOrder)
             ->toArray();
     }

--- a/tests/FieldTypesRequestTest.php
+++ b/tests/FieldTypesRequestTest.php
@@ -11,7 +11,7 @@ class FieldTypesRequestTest extends AbstractTestCase
     public function testRulesFormat()
     {
         $this->request->setRules('field', ['rule1', 'rule2']);
-        $this->assertEquals(['field' => 'rule1|rule2'], $this->request->rules());
+        $this->assertEquals(['field' => ['rule1', 'rule2']], $this->request->rules());
     }
 
     public function testMessagesFormat()
@@ -65,7 +65,7 @@ class FieldTypesRequestTest extends AbstractTestCase
     {
         $this->fieldTypeRules->put('field', collect(['rule']));
 
-        $this->assertEquals(['field' => 'rule'], $this->request->rules());
+        $this->assertEquals(['field' => ['rule']], $this->request->rules());
     }
 
     /***************************************************************************************************/


### PR DESCRIPTION
This is not necessary, rules can be passed as an array.
Concatenating with pipe can break regex validation.